### PR TITLE
fix(security): disable devDep automerge

### DIFF
--- a/javascript.json
+++ b/javascript.json
@@ -14,7 +14,6 @@
     {
       "matchDepTypes": ["devDependencies"],
       "labels": ["dependencies", "patch"],
-      "automerge": true,
       "semanticCommitScope": "dev-deps"
     },
     {


### PR DESCRIPTION
## Description

Removes `automerge: true` from the `devDependencies` rule. Combined with `bypass_pull_request_allowances` on branch protection, Renovate could self-merge devDep PRs to `main` with zero human approval. Removing automerge breaks that chain across all repos inheriting this config.

## Checklist

- [ ] 📕 Code follows the [Frontend Style Guide](https://gr4vy.atlassian.net/wiki/spaces/GB/pages/253657097/Frontend+Coding+Standards)
- [ ] 💅🏻 Designs match Figma and adhere to the design system.
- [ ] ♿️ Accessibility has been considered (e.g. focus states, color contrast)
- [ ] 🧪 Unit tests and stories have been added.