### PR TITLE
fix(security): add supply chain hardening to javascript.json

### DIFF
--- a/javascript.json
+++ b/javascript.json
@@ -2,6 +2,8 @@
   "extends": ["github>gr4vy/renovate-config", ":disablePeerDependencies"],
   "rangeStrategy": "bump",
   "assignAutomerge": true,
+  "prCreation": "not-pending",
+  "internalChecksFilter": "strict",
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": ["vulnerability"],
@@ -15,11 +17,13 @@
       "matchDepTypes": ["devDependencies"],
       "labels": ["dependencies", "patch"],
       "automerge": true,
+      "minimumReleaseAge": "3 days",
       "semanticCommitScope": "dev-deps"
     },
     {
       "matchDepTypes": ["dependencies"],
       "labels": ["dependencies", "minor"],
+      "minimumReleaseAge": "3 days",
       "semanticCommitScope": "deps"
     },
     {

--- a/javascript.json
+++ b/javascript.json
@@ -4,6 +4,7 @@
   "assignAutomerge": true,
   "prCreation": "not-pending",
   "internalChecksFilter": "strict",
+  "dependencyDashboard": true,
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": ["vulnerability"],

--- a/javascript.json
+++ b/javascript.json
@@ -2,7 +2,6 @@
   "extends": ["github>gr4vy/renovate-config", ":disablePeerDependencies"],
   "rangeStrategy": "bump",
   "assignAutomerge": true,
-  "prCreation": "not-pending",
   "internalChecksFilter": "strict",
   "dependencyDashboard": true,
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Description

Adds `minimumReleaseAge: "3 days"` to both `devDependencies` and `dependencies` rules, plus `prCreation: "not-pending"`, `internalChecksFilter: "strict"` and `dependencyDashboard: true` (creates a GitHub issue per repo listing all pending updates) at the top level. Together these prevent PRs from opening until a release is 3 days old, so CI never runs on a freshly published package.
<sub>(source: [renovate docs](https://docs.renovatebot.com/configuration-options/#suppress-branchpr-creation-for-x-days))</sub>

## Links

- JIRA - [TA-16112](https://gr4vy.atlassian.net/browse/TA-16112)

[TA-16112]: https://gr4vy.atlassian.net/browse/TA-16112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TA-16112]: https://gr4vy.atlassian.net/browse/TA-16112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ