### PR TITLE
change pattern to name on python matcher

### DIFF
--- a/python.json
+++ b/python.json
@@ -30,7 +30,7 @@
       "enabled": false
     },
     {
-      "matchPackagePatterns": ["python"],
+      "matchPackageNames": ["python"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
allow setup-python or other deps that contains the "python" string to be uptaded