### PR TITLE
chore: set default min age

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,5 +8,6 @@
     ":semanticCommits",
     ":semanticCommitTypeAll(chore)"
   ],
-  "labels": ["dependencies"]
+  "labels": ["dependencies"],
+  "minimumReleaseAge": "3 days"
 }


### PR DESCRIPTION
Set minimum age at root level for renovate.

We saw that a version of tanstack/router used in the payment-links repo was less than one day old which exposed us to a supply chain attack. Analysing our full renovate config with Claude:

> Based on the findings, here's why the tanstack/router group bypassed the min age:
> **The `tanstack-router monorepo` package rule has no `minimumReleaseAge` set, and the global default is `null`.**
> The age constraints that DO exist are scoped to specific dep types/update types:
> - devDependencies (patch/digest): `3 days`
> - dependencies (minor): `3 days`
> - dependencies (patch): `5 days`
> 
> The tanstack-router group rule only defines `matchSourceUrls` + `groupName` + `matchUpdateTypes` — it has no age override. Whether the age rules apply depends on rule ordering and matching:
> - In Renovate, `packageRules` are applied in order and **later rules override earlier ones for any properties they explicitly set**. If the tanstack-router rule comes _after_ the age rules but doesn't set `minimumReleaseAge`, the earlier rule's age should still hold — **unless** the update type isn't covered by the age rules.
>
> The most likely cause: if the tanstack/router PR was a **major** update, none of the age rules cover `major` for devDependencies, so it falls through to the global `null` — no minimum age at all. The age rules only explicitly cover `patch`, `digest`, and `minor` update types.
> To fix this, you'd add `"minimumReleaseAge": "3 days"` (or whatever threshold you want) directly to the tanstack-router package rule, or extend the dep-type age rules to also cover `major` updates.